### PR TITLE
Use composite keys

### DIFF
--- a/src/Fogger/Data/ChunkProducer.php
+++ b/src/Fogger/Data/ChunkProducer.php
@@ -41,14 +41,24 @@ class ChunkProducer
 
         $counter = 0;
         $keys = [];
+        $last_key = null;
 
-        while ($key = $result->fetchColumn()) {
+        while (($key = $result->fetchColumn()) !== False) {
             $keys[] = $key;
             $counter++;
             if (0 === $counter % $table->getChunkSize()) {
+
+                do {
+                    $last_key = $key;
+                    $key = $result->fetchColumn();
+                    $counter++;
+                } while ($last_key === $key);
+
                 $this->chunkCache->pushMessage($table, $keys);
                 $keys = [];
+                $keys[] = $key;
             }
+            $last_key = $key;
         }
         if (0 !== $counter % $table->getChunkSize()) {
             $this->chunkCache->pushMessage($table, $keys);

--- a/src/Fogger/Data/ChunkProducer.php
+++ b/src/Fogger/Data/ChunkProducer.php
@@ -36,8 +36,10 @@ class ChunkProducer
 
             return;
         }
-
-        $result = $this->sourceQuery->getAllKeysQuery($table)->execute();
+        
+        $query = $this->sourceQuery->getAllKeysQuery($table);
+        $query = $query->orderBy($table->getSortBy());
+        $result = $query->execute();
 
         $counter = 0;
         $keys = [];

--- a/src/Fogger/Recipe/RecipeTableFactory.php
+++ b/src/Fogger/Recipe/RecipeTableFactory.php
@@ -32,6 +32,14 @@ class RecipeTableFactory
                 return $index->getColumns()[0];
             }
         }
+        if ($table->getPrimaryKey()) {
+            return $table->getPrimaryKeyColumns()[0];
+        }
+        foreach ($table->getIndexes() as $index) {
+            if ($index->isUnique()) {
+                return $index->getColumns()[0];
+            }
+        }
 
         return null;
     }

--- a/src/Fogger/Recipe/RecipeTableFactory.php
+++ b/src/Fogger/Recipe/RecipeTableFactory.php
@@ -37,7 +37,11 @@ class RecipeTableFactory
         }
         foreach ($table->getIndexes() as $index) {
             if ($index->isUnique()) {
-                return $index->getColumns()[0];
+                foreach ($index->getColumns() as $column) {
+                    if ($table->getColumn($column)->getNotnull()) {
+                        return $column;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Rather than attempt to copy the entire table at once use the first field in a primary key or unique index if possible.